### PR TITLE
Fix build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,6 @@ module.exports = function (grunt) {
 				]
 			}
 		},
-
 		prompt: {
 			target: {
 				options: {
@@ -103,13 +102,13 @@ module.exports = function (grunt) {
 							config : 'pkg.version', // arbitrary name or config for any other grunt task
 							type   : 'input', // list, checkbox, confirm, input, password
 							message: 'Fabrik version:', // Question to ask the user, function needs to return a string,
-							default: grunt.config('pkg.version') // default value if nothing is entered
+							default: '4' //grunt.config('pkg.version') // default value if nothing is entered
 						},
 						{
 							config : 'jversion',
 							type   : 'input',
 							message: 'Joomla target version #',
-							default: '3'
+							default: '4'
 						},
 						{
 							config : 'live',
@@ -138,12 +137,14 @@ module.exports = function (grunt) {
 						{
 							config : 'phpdocs.create',
 							type   : 'confirm',
-							message: 'Build PHP Docs?'
+							message: 'Build PHP Docs?',
+							default: false
 						},
 						{
 							config : 'phpdocs.upload',
 							type   : 'confirm',
-							message: 'Upload PHP docs to fabrikar.com'
+							message: 'Upload PHP docs to fabrikar.com',
+							default: false
 						},
 					]
 				}
@@ -538,7 +539,9 @@ var packages = function (version, grunt) {
 			];
 			Promise.settle(promises)
 				.then(function () {
-					ftp(grunt, version);
+					if (grunt.config.get('upload.zips') || grunt.config.get('upload.xml')) {
+						ftp(grunt, version);
+					}
 				});
 
 		});

--- a/administrator/components/com_fabrik/pkg_fabrik.xml
+++ b/administrator/components/com_fabrik/pkg_fabrik.xml
@@ -2,22 +2,71 @@
 <extension type="package" version="4" method="upgrade">
 	<name>Fabrik Package</name>
 	<packagename>fabrik</packagename>
-	<version>4.0</version>
+	<version>4</version>
 	<url>http://www.fabrikar.com</url>
-	<creationDate>August 2021</creationDate>
-	<copyright>Copyright (C) 2005-2021 Media A-Team, Inc. - All rights reserved.</copyright>
+	<creationDate>July 2022</creationDate>
+	<copyright>Copyright (C) 2005-2022 Media A-Team, Inc. - All rights reserved.</copyright>
 	<author>Media A-Team, Inc.</author>
 	<packager>Rob Clayburn</packager>
 	<packagerurl>http://www.fabrikar.com</packagerurl>
 	<description>Fabrik Package</description>
 
+	<updateservers>
+		<server type="collection" name="Fabrik31">http://fabrikar.com/update/fabrik31/package_list.xml</server>
+	</updateservers>
+
 	<files folder="packages">
-		<file group="system" id="fabrik" type="plugin">plg_fabrik_system.zip</file>
 
-		<file group="fabrik_element" id="field" type="plugin">plg_fabrik_element_field.zip</file>
-		<file group="fabrik_element" id="internalid" type="plugin">plg_fabrik_element_internalid.zip</file>
-		<file group="fabrik_element" id="jdate" type="plugin">plg_fabrik_element_jdate.zip</file>
+		<file client="site" id="mod_fabrik_form" type="module">mod_fabrik_form_{version}.zip</file>
+		<file client="site" id="mod_fabrik_list" type="module">mod_fabrik_list_{version}.zip</file>
 
-		<file id="com_fabrik" type="component">com_fabrik.zip</file>
+		<file group="system" id="fabrik" type="plugin">plg_fabrik_system_{version}.zip</file>
+<!--
+		<file group="system" id="fabrikcron" type="plugin">plg_fabrik_schedule_{version}.zip</file>
+		<file group="content" id="fabrik" type="plugin">plg_fabrik_content_{version}.zip</file>
+
+		<file group="fabrik_cron" id="email" type="plugin">plg_fabrik_cron_email_{version}.zip</file>
+		<file group="fabrik_cron" id="php" type="plugin">plg_fabrik_cron_php_{version}.zip</file>
+-->
+		<file group="fabrik_element" id="field" type="plugin">plg_fabrik_element_field_{version}.zip</file>
+		<file group="fabrik_element" id="internalid" type="plugin">plg_fabrik_element_internalid_{version}.zip</file>
+		<file group="fabrik_element" id="jdate" type="plugin">plg_fabrik_element_jdate_{version}.zip</file>
+<!--
+		<file group="fabrik_element" id="button" type="plugin">plg_fabrik_element_button_{version}.zip</file>
+		<file group="fabrik_element" id="checkbox" type="plugin">plg_fabrik_element_checkbox_{version}.zip</file>
+		<file group="fabrik_element" id="databasejoin" type="plugin">plg_fabrik_element_databasejoin_{version}.zip</file>
+		<file group="fabrik_element" id="date" type="plugin">plg_fabrik_element_date_{version}.zip</file>
+		<file group="fabrik_element" id="display" type="plugin">plg_fabrik_element_display_{version}.zip</file>
+		<file group="fabrik_element" id="dropdown" type="plugin">plg_fabrik_element_dropdown_{version}.zip</file>
+		<file group="fabrik_element" id="fileupload" type="plugin">plg_fabrik_element_fileupload_{version}.zip</file>
+		<file group="fabrik_element" id="googlemap" type="plugin">plg_fabrik_element_googlemap_{version}.zip</file>
+		<file group="fabrik_element" id="image" type="plugin">plg_fabrik_element_image_{version}.zip</file>
+		<file group="fabrik_element" id="link" type="plugin">plg_fabrik_element_link_{version}.zip</file>
+		<file group="fabrik_element" id="radiobutton" type="plugin">plg_fabrik_element_radiobutton_{version}.zip</file>
+		<file group="fabrik_element" id="textarea" type="plugin">plg_fabrik_element_textarea_{version}.zip</file>
+		<file group="fabrik_element" id="user" type="plugin">plg_fabrik_element_user_{version}.zip</file>
+
+		<file group="fabrik_form" id="email" type="plugin">plg_fabrik_form_email_{version}.zip</file>
+		<file group="fabrik_form" id="php" type="plugin">plg_fabrik_form_php_{version}.zip</file>
+		<file group="fabrik_form" id="receipt" type="plugin">plg_fabrik_form_receipt_{version}.zip</file>
+		<file group="fabrik_form" id="redirect" type="plugin">plg_fabrik_form_redirect_{version}.zip</file>
+
+		<file group="fabrik_list" id="copy" type="plugin">plg_fabrik_list_copy_{version}.zip</file>
+		<file group="fabrik_list" id="php" type="plugin">plg_fabrik_list_php_{version}.zip</file>
+
+		<file group="fabrik_validationrule" id="isgreaterorlessthan" type="plugin">plg_fabrik_validationrule_isgreaterorlessthan_{version}.zip</file>
+		<file group="fabrik_validationrule" id="notempty" type="plugin">plg_fabrik_validationrule_notempty_{version}.zip</file>
+		<file group="fabrik_validationrule" id="php" type="plugin">plg_fabrik_validationrule_php_{version}.zip</file>
+		<file group="fabrik_validationrule" id="regex" type="plugin">plg_fabrik_validationrule_regex_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isemail" type="plugin">plg_fabrik_validationrule_isemail_{version}.zip</file>
+
+		<file group="fabrik_visualization" id="calendar" type="plugin">plg_fabrik_visualization_calendar_{version}.zip</file>
+		<file group="fabrik_visualization" id="chart" type="plugin">plg_fabrik_visualization_chart_{version}.zip</file>
+		<file group="fabrik_visualization" id="googlemap" type="plugin">plg_fabrik_visualization_googlemap_{version}.zip</file>
+		<file group="fabrik_visualization" id="fullcalendar" type="plugin">plg_fabrik_visualization_fullcalendar_{version}.zip</file>
+		<file group="fabrik_visualization" id="media" type="plugin">plg_fabrik_visualization_media_{version}.zip</file>
+		<file group="fabrik_visualization" id="slideshow" type="plugin">plg_fabrik_visualization_slideshow_{version}.zip</file>
+-->
+		<file id="com_fabrik" type="component">com_fabrik_{version}.zip</file>
 	</files>
 </extension>

--- a/administrator/components/com_fabrik/pkg_fabrik_sink.xml
+++ b/administrator/components/com_fabrik/pkg_fabrik_sink.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<extension type="package" version="4">
+	<name>Fabrik Package</name>
+	<packagename>fabrik</packagename>
+	<version>4</version>
+	<url>http://www.joomla.org</url>
+	<packager>Rob Clayburn</packager>
+	<packagerurl>http://www.fabrikar.com</packagerurl>
+	<creationDate>July 2022</creationDate>
+	<copyright>Copyright (C) 2005-2022 Media A-Team, Inc. - All rights reserved.</copyright>
+	<description>Fabrik Free Package</description>
+	<update>http://fabrikar.com/update/packages/free</update>
+	<files folder="packages">
+
+		<file id="com_fabrik" type="component">com_fabrik_{version}.zip</file>
+		<file client="site" id="mod_fabrik_form" type="module">mod_fabrik_form_{version}.zip</file>
+		<file client="site" id="mod_fabrik_list" type="module">mod_fabrik_list_{version}.zip</file>
+
+		<file group="content" id="fabrik" type="plugin">plg_fabrik_{version}.zip</file>
+		<file group="editors-xtd" id="plg_fabrik" type="plugin">plg_fabrik_cck_editor_{version}.zip</file>
+
+		<file group="fabrik_cron" id="email" type="plugin">plg_fabrik_cron_email_{version}.zip</file>
+		<file group="fabrik_cron" id="gcalsync" type="plugin">plg_fabrik_cron_gcalsync_{version}.zip</file>
+		<file group="fabrik_cron" id="geocode" type="plugin">plg_fabrik_cron_geocode_{version}.zip</file>
+		<file group="fabrik_cron" id="gmail" type="plugin">plg_fabrik_cron_gmail_{version}.zip</file>
+		<file group="fabrik_cron" id="notification" type="plugin">plg_fabrik_cron_notification_{version}.zip</file>
+		<file group="fabrik_cron" id="php" type="plugin">plg_fabrik_cron_php_{version}.zip</file>
+
+		<file group="fabrik_element" id="access" type="plugin">plg_fabrik_element_access_{version}.zip</file>
+		<file group="fabrik_element" id="birthday" type="plugin">plg_fabrik_element_birthday_{version}.zip</file>
+		<file group="fabrik_element" id="button" type="plugin">plg_fabrik_element_button_{version}.zip</file>
+		<file group="fabrik_element" id="calc" type="plugin">plg_fabrik_element_calc_{version}.zip</file>
+		<file group="fabrik_element" id="captcha" type="plugin">plg_fabrik_element_captcha_{version}.zip</file>
+		<file group="fabrik_element" id="checkbox" type="plugin">plg_fabrik_element_checkbox_{version}.zip</file>
+		<file group="fabrik_element" id="colourpicker" type="plugin">plg_fabrik_element_colourpicker_{version}.zip</file>
+		<file group="fabrik_element" id="count" type="plugin">plg_fabrik_element_count_{version}.zip</file>
+		<file group="fabrik_element" id="databasejoin" type="plugin">plg_fabrik_element_databasejoin_{version}.zip</file>
+		<file group="fabrik_element" id="date" type="plugin">plg_fabrik_element_date_{version}.zip</file>
+		<file group="fabrik_element" id="display" type="plugin">plg_fabrik_element_display_{version}.zip</file>
+		<file group="fabrik_element" id="dropdown" type="plugin">plg_fabrik_element_dropdown_{version}.zip</file>
+		<file group="fabrik_element" id="fbactivity" type="plugin">plg_fabrik_element_fbactivity_{version}.zip</file>
+		<file group="fabrik_element" id="fbcomment" type="plugin">plg_fabrik_element_fbcomment_{version}.zip</file>
+		<file group="fabrik_element" id="fblike" type="plugin">plg_fabrik_element_fblike_{version}.zip</file>
+		<file group="fabrik_element" id="fbrecommendations" type="plugin">plg_fabrik_element_fbrecommendations_{version}.zip</file>
+		<file group="fabrik_element" id="field" type="plugin">plg_fabrik_element_field_{version}.zip</file>
+		<file group="fabrik_element" id="fileupload" type="plugin">plg_fabrik_element_fileupload_{version}.zip</file>
+		<file group="fabrik_element" id="folder" type="plugin">plg_fabrik_element_folder_{version}.zip</file>
+		<file group="fabrik_element" id="googlemap" type="plugin">plg_fabrik_element_googlemap_{version}.zip</file>
+		<file group="fabrik_element" id="googleometer" type="plugin">plg_fabrik_element_googleometer_{version}.zip</file>
+		<file group="fabrik_element" id="image" type="plugin">plg_fabrik_element_image_{version}.zip</file>
+		<file group="fabrik_element" id="internalid" type="plugin">plg_fabrik_element_internalid_{version}.zip</file>
+		<file group="fabrik_element" id="ip" type="plugin">plg_fabrik_element_ip_{version}.zip</file>
+		<file group="fabrik_element" id="jdate" type="plugin">plg_fabrik_element_jdate_{version}.zip</file>
+		<file group="fabrik_element" id="jsperiodical" type="plugin">plg_fabrik_element_jsperiodical_{version}.zip</file>
+		<file group="fabrik_element" id="kaltura" type="plugin">plg_fabrik_element_kaltura_{version}.zip</file>
+		<file group="fabrik_element" id="link" type="plugin">plg_fabrik_element_link_{version}.zip</file>
+		<file group="fabrik_element" id="password" type="plugin">plg_fabrik_element_password_{version}.zip</file>
+		<file group="fabrik_element" id="picklist" type="plugin">plg_fabrik_element_picklist_{version}.zip</file>
+		<file group="fabrik_element" id="radiobutton" type="plugin">plg_fabrik_element_radiobutton_{version}.zip</file>
+		<file group="fabrik_element" id="rating" type="plugin">plg_fabrik_element_rating_{version}.zip</file>
+		<file group="fabrik_element" id="sql" type="plugin">plg_fabrik_element_sql_{version}.zip</file>
+		<file group="fabrik_element" id="textarea" type="plugin">plg_fabrik_element_textarea_{version}.zip</file>
+		<file group="fabrik_element" id="thumbs" type="plugin">plg_fabrik_element_thumbs_{version}.zip</file>
+		<file group="fabrik_element" id="timer" type="plugin">plg_fabrik_element_timer_{version}.zip</file>
+		<file group="fabrik_element" id="timestamp" type="plugin">plg_fabrik_element_timestamp_{version}.zip</file>
+		<file group="fabrik_element" id="user" type="plugin">plg_fabrik_element_user_{version}.zip</file>
+		<file group="fabrik_element" id="yesno" type="plugin">plg_fabrik_element_yesno_{version}.zip</file>
+		<file group="fabrik_element" id="youtube" type="plugin">plg_fabrik_element_youtube_{version}.zip</file>
+
+		<file group="fabrik_form" id="alphauserpoints" type="plugin">plg_fabrik_form_alphauserpoints_{version}.zip</file>
+		<file group="fabrik_form" id="article" type="plugin">plg_fabrik_form_article_{version}.zip</file>
+		<file group="fabrik_form" id="autofill" type="plugin">plg_fabrik_form_autofill_{version}.zip</file>
+		<file group="fabrik_form" id="clone" type="plugin">plg_fabrik_form_clone_{version}.zip</file>
+		<file group="fabrik_form" id="comment" type="plugin">plg_fabrik_form_comment_{version}.zip</file>
+		<file group="fabrik_form" id="confirmation" type="plugin">plg_fabrik_form_confirmation_{version}.zip</file>
+		<file group="fabrik_form" id="email" type="plugin">plg_fabrik_form_email_{version}.zip</file>
+		<file group="fabrik_form" id="exif" type="plugin">plg_fabrik_form_exif_{version}.zip</file>
+		<file group="fabrik_form" id="ftp" type="plugin">plg_fabrik_form_ftp_{version}.zip</file>
+		<file group="fabrik_form" id="j2store" type="plugin">plg_fabrik_form_j2store_{version}.zip</file>
+		<file group="fabrik_form" id="joompush" type="plugin">plg_fabrik_form_joompush_{version}.zip</file>
+		<file group="fabrik_form" id="juser" type="plugin">plg_fabrik_form_juser_{version}.zip</file>
+		<file group="fabrik_form" id="kunena" type="plugin">plg_fabrik_form_kunena_{version}.zip</file>
+		<file group="fabrik_form" id="limit" type="plugin">plg_fabrik_form_limit_{version}.zip</file>
+		<file group="fabrik_form" id="logs" type="plugin">plg_fabrik_form_logs_{version}.zip</file>
+		<file group="fabrik_form" id="notification" type="plugin">plg_fabrik_form_notification_{version}.zip</file>
+		<file group="fabrik_form" id="paypal" type="plugin">plg_fabrik_form_paypal_{version}.zip</file>
+		<file group="fabrik_form" id="php" type="plugin">plg_fabrik_form_php_{version}.zip</file>
+		<file group="fabrik_form" id="receipt" type="plugin">plg_fabrik_form_receipt_{version}.zip</file>
+		<file group="fabrik_form" id="redirect" type="plugin">plg_fabrik_form_redirect_{version}.zip</file>
+		<file group="fabrik_form" id="salesforce" type="plugin">plg_fabrik_form_salesforce_{version}.zip</file>
+		<file group="fabrik_form" id="sms" type="plugin">plg_fabrik_form_sms_{version}.zip</file>
+		<file group="fabrik_form" id="twitter" type="plugin">plg_fabrik_form_twitter_{version}.zip</file>
+		<file group="fabrik_form" id="upsert" type="plugin">plg_fabrik_form_upsert_{version}.zip</file>
+
+		<file group="fabrik_list" id="copy" type="plugin">plg_fabrik_list_copy_{version}.zip</file>
+		<file group="fabrik_list" id="download" type="plugin">plg_fabrik_list_download_{version}.zip</file>
+		<file group="fabrik_list" id="inlineedit" type="plugin">plg_fabrik_list_inlineedit_{version}.zip</file>
+		<file group="fabrik_list" id="php" type="plugin">plg_fabrik_list_php_{version}.zip</file>
+		<file group="fabrik_list" id="radius_search" type="plugin">plg_fabrik_list_radius_search_{version}.zip</file>
+
+		<file group="system" id="fabrikcron" type="plugin">plg_fabrik_schedule_{version}.zip</file>
+
+		<file group="search" id="search" type="plugin">plg_fabrik_search_{version}.zip</file>
+
+		<file group="fabrik_validationrule" id="akismet" type="plugin">plg_fabrik_validation_akismet_{version}.zip</file>
+		<file group="fabrik_validationrule" id="emailexists" type="plugin">plg_fabrik_validation_emailexists_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isalphanumeric" type="plugin">plg_fabrik_validation_isalphanumeric_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isemail" type="plugin">plg_fabrik_validation_isemail_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isgreaterorlessthan" type="plugin">plg_fabrik_validation_isgreaterorlessthan_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isnot" type="plugin">plg_fabrik_validation_isnot_{version}.zip</file>
+		<file group="fabrik_validationrule" id="isnumeric" type="plugin">plg_fabrik_validation_isnumeric_{version}.zip</file>
+		<file group="fabrik_validationrule" id="notempty" type="plugin">plg_fabrik_validation_notempty_{version}.zip</file>
+		<file group="fabrik_validationrule" id="php" type="plugin">plg_fabrik_validation_php_{version}.zip</file>
+		<file group="fabrik_validationrule" id="regex" type="plugin">plg_fabrik_validation_regex_{version}.zip</file>
+		<file group="fabrik_validationrule" id="specialchars" type="plugin">plg_fabrik_validation_specialchars_{version}.zip</file>
+		<file group="fabrik_validationrule" id="userexists" type="plugin">plg_fabrik_validation_userexists_{version}.zip</file>
+
+		<file group="fabrik_visualization" id="calendar" type="plugin">plg_fabrik_visualization_calendar_{version}.zip</file>
+		<file group="fabrik_visualization" id="fullcalendar" type="plugin">plg_fabrik_visualization_fullcalendar_{version}.zip</file>
+		<file group="fabrik_visualization" id="chart" type="plugin">plg_fabrik_visualization_chart_{version}.zip</file>
+		<file group="fabrik_visualization" id="coverflow" type="plugin">plg_fabrik_visualization_coverflow_{version}.zip</file>
+		<file group="fabrik_visualization" id="fusion_gantt_chart" type="plugin">plg_fabrik_visualization_fusion_gantt_chart_{version}.zip</file>
+		<file group="fabrik_visualization" id="fusionchart" type="plugin">plg_fabrik_visualization_fusionchart_{version}.zip</file>
+		<file group="fabrik_visualization" id="googlemap" type="plugin">plg_fabrik_visualization_googlemap_{version}.zip</file>
+		<file group="fabrik_visualization" id="media" type="plugin">plg_fabrik_visualization_media_{version}.zip</file>
+		<file group="fabrik_visualization" id="slideshow" type="plugin">plg_fabrik_visualization_slideshow_{version}.zip</file>
+
+	</files>
+</extension>

--- a/fabrik_build/build-config.js
+++ b/fabrik_build/build-config.js
@@ -8,9 +8,14 @@ module.exports = {
         'visualization'
     ],
     'corePackageFiles': [
+        'plg_fabrik_system_{version}.zip',
+        'plg_fabrik_element_jdate_{version}.zip',
+        'plg_fabrik_element_internalid_{version}.zip',
+        'plg_fabrik_element_field_{version}.zip',
+        'com_fabrik_{version}.zip',
         'mod_fabrik_form_{version}.zip',
         'mod_fabrik_list_{version}.zip',
-        'plg_fabrik_system_{version}.zip',
+/*
         'plg_fabrik_schedule_{version}.zip',
         'plg_fabrik_content_{version}.zip',
         'plg_fabrik_cron_email_{version}.zip',
@@ -19,14 +24,11 @@ module.exports = {
         'plg_fabrik_element_checkbox_{version}.zip',
         'plg_fabrik_element_databasejoin_{version}.zip',
         'plg_fabrik_element_date_{version}.zip',
-        'plg_fabrik_element_jdate_{version}.zip',
         'plg_fabrik_element_display_{version}.zip',
         'plg_fabrik_element_dropdown_{version}.zip',
-        'plg_fabrik_element_field_{version}.zip',
         'plg_fabrik_element_fileupload_{version}.zip',
         'plg_fabrik_element_googlemap_{version}.zip',
         'plg_fabrik_element_image_{version}.zip',
-        'plg_fabrik_element_internalid_{version}.zip',
         'plg_fabrik_element_link_{version}.zip',
         'plg_fabrik_element_radiobutton_{version}.zip',
         'plg_fabrik_element_textarea_{version}.zip',
@@ -44,11 +46,11 @@ module.exports = {
         'plg_fabrik_validationrule_isemail_{version}.zip',
         'plg_fabrik_visualization_chart_{version}.zip',
         'plg_fabrik_visualization_fullcalendar_{version}.zip',
-	    'plg_fabrik_visualization_calendar_{version}.zip',
+        'plg_fabrik_visualization_calendar_{version}.zip',
         'plg_fabrik_visualization_googlemap_{version}.zip',
         'plg_fabrik_visualization_media_{version}.zip',
         'plg_fabrik_visualization_slideshow_{version}.zip',
-        'com_fabrik_{version}.zip'
+*/        
     ],
     'modules'         : [
         {


### PR DESCRIPTION
You can now build the fabrik installation package using grunt. Note, I reinstated the pkg_fabrik_sink.xml file as this one builds an entrie fabrik package with all plugins etc. I assume at some point we may need it.

The 2 important files are fabrik_build/build-config.js and administrator/components/com_fabrik/pkg_fabrik.xml files. In these files you will uncomment plugins as you test them. At the time of this PR the only plugins that are installed are the fabrik system plugin, and the field, internalid and jdate element plugins.

Additional note: in the Grundfile.js file I have set defaults for the various prompts. For now this just allows us to hit return to take the appropriate defaults while we are testing. Once a release is made then we will need to adjust the default setting for the pkg.version.