### PR TITLE
Fix class/function translation error for JLayout

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -8214,11 +8214,11 @@ class PlgFabrik_Element extends FabrikPlugin
 	}
 
 	/**
-	 * Add any jsLayoutInterface templates to Fabrik.jLayouts js object.
+	 * Add any jsJLayout templates to Fabrik.jLayouts js object.
 	 *
 	 * @return void
 	 */
-	public function jsLayoutInterfaces()
+	public function jsJLayout()
 	{
 	}
 

--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -5495,7 +5495,7 @@ class FabrikFEModelForm extends FabModelForm
 
 			foreach ($elementModels as $elementModel)
 			{
-				$elementModel->jsLayoutInterfaces();
+				$elementModel->jsJLayout();
 			}
 		}
 	}

--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -3041,11 +3041,11 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 	}
 
 	/**
-	 * Add any jsLayoutInterface templates to Fabrik.jLayouts js object.
+	 * Add any jsJLayout templates to Fabrik.jLayouts js object.
 	 *
 	 * @return void
 	 */
-	public function jsLayoutInterfaces()
+	public function jsJLayout()
 	{
 		$opts = $this->elementJavascriptOpts();
 		$params = $this->getParams();


### PR DESCRIPTION
The j4class translation mechanism inadvertently changed a couple of function names. This commit reverts them to what they should be.