### PR TITLE
Attempt to fix both popup close and tabs in admin from disappearing

### DIFF
--- a/media/com_fabrik/js/mootools-ext.js
+++ b/media/com_fabrik/js/mootools-ext.js
@@ -135,11 +135,11 @@ Element.implement({
 	 */
 
 	hide: function () {
-		/* This was stopping the popup models for admin to not close 
-		if (Fabrik.bootstrapVersion('modal') >= 3) {
+		if (this.parentNode.dataset.modalContent === undefined 
+			&& this.dataset.modalContent === undefined
+			&& Fabrik.bootstrapVersion('modal') >= 3) {
 			return;
 		}
-		*/
 		if (this.hasClass('mootools-noconflict')) {
 			return this;
 		}


### PR DESCRIPTION
A little more robust. It may yet cause issues elsewhere as this is just a hack. But so far seems to be working.