### PR TITLE
If the content is an array, explode it before appending to the output…

### DIFF
--- a/libraries/fabrik/fabrik/Document/Renderer/Partial/HeadRenderer.php
+++ b/libraries/fabrik/fabrik/Document/Renderer/Partial/HeadRenderer.php
@@ -387,6 +387,9 @@ class HeadRenderer extends DocumentRenderer
 				$buffer .= $tab . $tab . '//<![CDATA[' . $lnEnd;
 			}
 
+			if (is_array($content)) {
+				$content = implode(' ', $content);
+			}
 			$buffer .= $content . $lnEnd;
 
 			// See above note


### PR DESCRIPTION
… buffer

php8 was complaining about an array to string conversion, so do it ourselves.