### PR TITLE
Remove empty fabrik plugin folders on uninstall

### DIFF
--- a/administrator/components/com_fabrik/com_fabrik.manifest.class.php
+++ b/administrator/components/com_fabrik/com_fabrik.manifest.class.php
@@ -262,8 +262,13 @@ class Com_FabrikInstallerScript
 			// Remove empty folders if exist
 			$path = JPATH_ROOT.'/media/com_fabrik';		
 			if(Folder::exists($path)) Folder::delete($path);
-			$path = JPATH_ROOT.'/plugins/fabrik_element';		
-			if(Folder::exists($path)) Folder::delete($path);
+			$pluginFolders =['comunnity/fabrik', 'content/fabrik', 'fabrik_cron', 'fabrik_element', 'fabrik_form', 'fabrik_list', 'fabrik_validationrule', 'fabrik_visualization', 'search/fabrik', 'system/fabrik', 'system/fabrik_cron', 'system/fabrikj2store'];
+			foreach ($pluginFolders as $pluginFolder) {
+				$path = JPATH_ROOT.'/plugins/'.$pluginFolder;	
+				if (Folder::exists($path) && empty(Folder::files($path))) {
+					Folder::delete($path);
+				}
+			}
 			// Remove our admin template override
 			$this->templateOverride(false);
 		}


### PR DESCRIPTION
Uninstall did not automatically remove them so I am doing it in postflight when an uninstall. It will check if the plugin folder is empty before attempting to delete it, just in case the component is being uninstalled but not the plugins.