### PR TITLE
Bootstrap ReTip AdminForm labels (descriptions)

### DIFF
--- a/administrator/components/com_fabrik/layouts/joomla/form/renderlabel.php
+++ b/administrator/components/com_fabrik/layouts/joomla/form/renderlabel.php
@@ -46,6 +46,7 @@ if (!empty($description))
 	{
 		HTMLHelper::_('bootstrap.tooltip','.hasTooltip');
 		$classes[] = 'hasTooltip';
+		$classes[] = 'FabrikAdminLabel';
 		$title     = ' title="' . HTMLHelper::_('tooltipText', trim($text, ':'), $description, 0) . '"';
 	}
 }
@@ -60,5 +61,7 @@ if ($required)
 
 ?>
 <label id="<?php echo $id; ?>" for="<?php echo $for; ?>"<?php if (!empty($classes)) { echo ' class="' . implode(' ', $classes) . '"';} ?><?php echo $title; ?>>
-	<?php echo $text; ?><?php if ($required) : ?><span class="star" aria-hidden="true">&#160;*</span><?php endif; ?>
+	<?php echo $text; ?>
+	<?php if ($required) : ?><span class="star" aria-hidden="true">&#160;*</span><?php endif;
+	if (!empty($description)) : ?><span class="star" aria-hidden="true">&#160;&#9432;</span><?php endif; ?>
 </label>

--- a/administrator/components/com_fabrik/views/namespace.js
+++ b/administrator/components/com_fabrik/views/namespace.js
@@ -32,6 +32,11 @@
 			jQuery(document).popover({selector: '.hasPopover', trigger: 'hover'});
 		}
 */
+		//Joomla4: initialize bootstrap tooltips
+		var tooltipTriggerList = [].slice.call(document.querySelectorAll('.FabrikAdminLabel'))
+		var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+		  return new bootstrap.Tooltip(tooltipTriggerEl)
+		})
 	};
 
 	window.fireEvent('fabrik.admin.namespace');


### PR DESCRIPTION
"Black on white" tooltip in plugins is just the browser displaying the title (including HTML tags etc) https://github.com/joomlahenk/fabrik/issues/157.
But administrator/components/com_fabrik/views/namespace.js was the right hint for adding the reTip via bootstrap
I added also an "i" icon to labels with descriptions.
Different trigger class in namespace.js used because with the same class as in renderlabel.php on my site the tooltips in the "main" part didn't close.

namespace.js needs minifying