### PR TITLE
Fix error message in viewlevel element plugin.

### DIFF
--- a/plugins/fabrik_element/viewlevel/viewlevel.php
+++ b/plugins/fabrik_element/viewlevel/viewlevel.php
@@ -67,7 +67,7 @@ class PlgFabrik_ElementViewlevel extends PlgFabrik_ElementList
 		{
 			$data = new stdClass;
 
-			return $this->renderListData($selected[0], $data);
+			return $this->renderListData($selected, $data);
 		}
 
 		$options = array();


### PR DESCRIPTION
The selected value is either a number or a name, it is not an array