### PR TITLE
Remove form-horizontal class. Not used in BS5.

### DIFF
--- a/administrator/components/com_fabrik/models/plugin.php
+++ b/administrator/components/com_fabrik/models/plugin.php
@@ -149,7 +149,7 @@ class FabrikAdminModelPlugin extends BaseDatabaseModel
 	{
 		$data                   = $this->getData();
 		$c                      = $this->getState('c') + 1;
-		$class                  = 'form-horizontal ';
+		$class                  = '';
 		$str                    = array();
 		$str[]                  = '<div class="pane-slider content pane-down accordion-inner">';
 		$str[]                  = '<fieldset class="' . $class . 'pluginContainer" id="formAction_' . $c . '"><ul>';

--- a/administrator/components/com_fabrik/views/connection/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/connection/tmpl/bootstrap.php
@@ -30,7 +30,7 @@ HTMLHelper::_('behavior.keepalive');
 				<label><?php echo Text::_('COM_FABRIK_ENTER_PASSWORD_OR_LEAVE_AS_IS'); ?></label>
 			</li>
 		<?php endif; ?>
-		<fieldset class="form-horizontal">
+		<fieldset>
 	    	<legend>
 	    		<?php echo Text::_('COM_FABRIK_DETAILS');?>
 	    	</legend>

--- a/administrator/components/com_fabrik/views/cron/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/cron/tmpl/bootstrap.php
@@ -44,7 +44,7 @@ HTMLHelper::_('behavior.keepalive');
 
 	<div class="row">
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 		    	<legend>
 		    		<?php echo Text::_('COM_FABRIK_DETAILS');?>
 		    	</legend>
@@ -72,7 +72,7 @@ HTMLHelper::_('behavior.keepalive');
 
 		<div class="col-md-6">
 
-			<fieldset class="form-horizontal">
+			<fieldset>
 		    	<legend>
 		    		<?php echo Text::_('COM_FABRIK_RUN');?>
 		    	</legend>
@@ -82,7 +82,7 @@ HTMLHelper::_('behavior.keepalive');
 				?>
 			</fieldset>
 
-			<fieldset class="form-horizontal">
+			<fieldset>
 		    	<legend>
 		    		<?php echo Text::_('COM_FABRIK_LOG');?>
 		    	</legend>
@@ -95,7 +95,7 @@ HTMLHelper::_('behavior.keepalive');
 	</div>
 	<div class="row">
 		<div class="col-md-12">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<div id="plugin-container">
 					<?php echo $this->pluginFields;?>
 				</div>

--- a/administrator/components/com_fabrik/views/element/tmpl/bootstrap_access.php
+++ b/administrator/components/com_fabrik/views/element/tmpl/bootstrap_access.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="tab-pane" id="tab-access">
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<legend><?php echo Text::_('COM_FABRIK_GROUP_LABEL_RULES_DETAILS'); ?></legend>
 		<?php
 		foreach ($this->form->getFieldset('access') as $this->field) :

--- a/administrator/components/com_fabrik/views/element/tmpl/bootstrap_details.php
+++ b/administrator/components/com_fabrik/views/element/tmpl/bootstrap_details.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="tab-pane active" id="tab-details">
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<!-- <legend><?php echo Text::_('COM_FABRIK_DETAILS');?></legend> -->
 		<input type="hidden" id="name_orig" name="name_orig" value="<?php echo $this->item->name; ?>" />
 		<input type="hidden" id="plugin_orig" name="plugin_orig" value="<?php echo $this->item->plugin; ?>" />
@@ -35,7 +35,7 @@ use Joomla\CMS\Language\Text;
 
 	</fieldset>
 
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<div id="plugin-container">
 		<?php echo $this->pluginFields; ?>
 		</div>

--- a/administrator/components/com_fabrik/views/element/tmpl/bootstrap_listview.php
+++ b/administrator/components/com_fabrik/views/element/tmpl/bootstrap_listview.php
@@ -48,7 +48,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="tab-content">
 		<div class="tab-pane active" id="listview-details">
-		    <fieldset class="form-horizontal">
+		    <fieldset>
 				<?php foreach ($this->form->getFieldset('listsettings') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -61,7 +61,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="listview-icons">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('icons') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -70,7 +70,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="listview-filters">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('filters') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -83,7 +83,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="listview-css">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('viewcss') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;

--- a/administrator/components/com_fabrik/views/element/tmpl/bootstrap_publishing.php
+++ b/administrator/components/com_fabrik/views/element/tmpl/bootstrap_publishing.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="tab-pane" id="tab-publishing">
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<legend><?php echo Text::_('COM_FABRIK_PUBLISHING');?></legend>
 		<ul class="nav nav-tabs">
 			  <li class="nav-item" role="">
@@ -39,7 +39,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="tab-content">
 		<div class="tab-pane active" id="publishing-details">
-		    <fieldset class="form-horizontal">
+		    <fieldset>
 				<?php foreach ($this->form->getFieldset('publishing') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -48,7 +48,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="publishing-rss">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('rss') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -57,7 +57,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="publishing-tips">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('tips') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_buttons.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_buttons.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="row">
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_COPY');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-copy') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -29,7 +29,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_RESET');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-reset') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -42,7 +42,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="row">
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_APPLY');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-apply') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -52,7 +52,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_BACK');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-goback') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -65,7 +65,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="row">
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_SAVE');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-save') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -74,7 +74,7 @@ use Joomla\CMS\Language\Text;
 			</fieldset>
 		</div>
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_DELETE');?></legend>
 				<?php foreach ($this->form->getFieldset('buttons-delete') as $this->field) :
 					echo $this->loadTemplate('control_group');

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_details.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_details.php
@@ -17,14 +17,14 @@ use Joomla\CMS\Language\Text;
 <div class="tab-pane active" id="tab-details">
 
 	    <legend><?php echo Text::_('COM_FABRIK_DETAILS'); ?></legend>
-	    <fieldset class="form-horizontal">
+	    <fieldset>
 			<?php foreach ($this->form->getFieldset('details') as $this->field) :
 				echo $this->loadTemplate('control_group');
 			endforeach;
 			?>
 		</fieldset>
 
-	    <fieldset class="form-horizontal">
+	    <fieldset>
 
 			<?php foreach ($this->form->getFieldset('details2') as $this->field) :
 				echo $this->loadTemplate('control_group');

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_groups.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_groups.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="tab-pane" id="tab-groups">
  	<legend><?php echo Text::_('COM_FABRIK_GROUPS'); ?></legend>
-   <fieldset class="form-horizontal">
+   <fieldset>
 		<?php foreach ($this->form->getFieldset('groups') as $this->field) :
 			echo $this->loadTemplate('control_group');
 		endforeach;

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_options.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_options.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 <div class="tab-pane" id="tab-options">
 
 	<legend><?php echo Text::_('COM_FABRIK_OPTIONS'); ?></legend>
-    <fieldset class="form-horizontal">
+    <fieldset>
 		<?php foreach ($this->form->getFieldset('options') as $this->field) :
 			echo $this->loadTemplate('control_group');
 		endforeach;

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_plugins.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_plugins.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Language\Text;
 <div class="tab-pane" id="tab-plugins">
 
 	<legend><?php echo Text::_('COM_FABRIK_PLUGINS'); ?></legend>
-	    <fieldset class="form-horizontal">
+	    <fieldset>
 			<div id="plugins"></div>
 			<a href="#" class="btn" id="addPlugin">
 				<i class="icon-plus"></i> <?php echo Text::_('COM_FABRIK_ADD'); ?></a>

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_process.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_process.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="tab-pane" id="tab-process">
 
-    <fieldset class="form-horizontal">
+    <fieldset>
 	    <legend><?php echo Text::_('COM_FABRIK_FORM_PROCESSING'); ?></legend>
 		<div class="control-group">
 			<div class="control-label">
@@ -48,7 +48,7 @@ use Joomla\CMS\Language\Text;
 		?>
 	</fieldset>
 
-    <fieldset class="form-horizontal">
+    <fieldset>
 		<legend><?php echo Text::_('COM_FABRIK_NOTES');?></legend>
 		<?php foreach ($this->form->getFieldset('notes') as $this->field) :
 			echo $this->loadTemplate('control_group');

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_publishing.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_publishing.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="tab-pane" id="tab-publishing">
 	<legend><?php echo Text::_('COM_FABRIK_PUBLISHING'); ?></legend>
-    <fieldset class="form-horizontal">
+    <fieldset>
 		<?php foreach ($this->form->getFieldset('publishing') as $this->field) :
 			echo $this->loadTemplate('control_group');
 		endforeach;

--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_templates.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_templates.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Language\Text;
 
 <div class="row">
 	<div class="col-md-12">
-		<fieldset class="form-horizontal">
+		<fieldset>
 	    <legend>
 			<?php echo Text::_('COM_FABRIK_FRONT_END_TEMPLATES'); ?>
 		</legend>
@@ -36,7 +36,7 @@ use Joomla\CMS\Language\Text;
 
 	<div class="col-md-12">
 
-    <fieldset class="form-horizontal">
+    <fieldset>
     	<legend>
 			<?php echo Text::_('COM_FABRIK_ADMIN_TEMPLATES'); ?>
 		</legend>
@@ -50,7 +50,7 @@ use Joomla\CMS\Language\Text;
 
 
 
-	<fieldset class="form-horizontal">
+	<fieldset>
     	<legend>
 			<?php echo Text::_('COM_FABRIK_LAYOUT'); ?>
 		</legend>

--- a/administrator/components/com_fabrik/views/group/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/group/tmpl/bootstrap.php
@@ -49,7 +49,7 @@ HTMLHelper::_('behavior.keepalive');
 			<div class="tab-content">
 
 				<div class="tab-pane active" id="details-info">
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_DETAILS');?>
 						</legend>
@@ -64,7 +64,7 @@ HTMLHelper::_('behavior.keepalive');
 				</div>
 
 				<div class="tab-pane" id="details-repeat">
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_REPEAT');?>
 						</legend>
@@ -76,7 +76,7 @@ HTMLHelper::_('behavior.keepalive');
 				</div>
 
 				<div class="tab-pane" id="details-layout">
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_LAYOUT');?>
 						</legend>
@@ -88,7 +88,7 @@ HTMLHelper::_('behavior.keepalive');
 				</div>
 
 				<div class="tab-pane" id="details-multipage">
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_GROUP_MULTIPAGE');?>
 						</legend>

--- a/administrator/components/com_fabrik/views/import/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/import/tmpl/bootstrap.php
@@ -68,7 +68,7 @@ window.addEvent('domready', function () {
 
 	<?php
 	foreach ($fieldsets as $n => $fieldset) :?>
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<?php
 		if ($n == 0) :
 			echo '<legend>' . Text::_('COM_FABRIK_IMPORT_CSV') . '</legend>';

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_access.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_access.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="tab-pane" id="access">
 <legend><?php echo Text::_('COM_FABRIK_GROUP_LABEL_RULES_DETAILS'); ?></legend>
-   <fieldset class="form-horizontal">
+   <fieldset>
 		<?php
 		foreach ($this->form->getFieldset('access') as $this->field) :
 			echo $this->loadTemplate('control_group');

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_data.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_data.php
@@ -52,7 +52,7 @@ $rtlDirInv = $doc->direction === 'rtl' ? 'right' : 'left';
 	<div class="tab-content">
 		<div class="tab-pane active" id="data-data">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 			<?php
 			$this->field = $this->form->getField('connection_id');
 			echo $this->loadTemplate('control_group');
@@ -91,7 +91,7 @@ $rtlDirInv = $doc->direction === 'rtl' ? 'right' : 'left';
 
 		<div class="tab-pane" id="data-groupby">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 			<?php
 			foreach ($this->form->getFieldset('grouping') as $this->field):
 				echo $this->loadTemplate('control_group');
@@ -105,7 +105,7 @@ $rtlDirInv = $doc->direction === 'rtl' ? 'right' : 'left';
 
 		<div class="tab-pane" id="data-prefilter">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 			<legend><?php echo Text::_('COM_FABRIK_PREFILTERS')?></legend>
 
 			 <a class="btn" href="#" onclick="oAdminFilters.addFilterOption(); return false;">

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_details.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_details.php
@@ -59,7 +59,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="details-filters">
 			<legend></legend>
-		    <fieldset class="form-horizontal">
+		    <fieldset>
 				<?php
 				foreach ($this->form->getFieldset('main_filter') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -73,7 +73,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane active" id="details-publishing">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('main') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -87,7 +87,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="details-nav">
 			<legend></legend>
-			 <fieldset class="form-horizontal">
+			 <fieldset>
 				<?php
 				foreach ($this->form->getFieldset('main_nav') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -101,7 +101,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="details-layout">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<div class="row">
 					<div>
 						<legend><?php echo Text::_('COM_FABRIK_TEMPLATES')?></legend>
@@ -125,7 +125,7 @@ use Joomla\CMS\Language\Text;
 				</div>
 			</fieldset>
 
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<div class="row">
 					<div>
 						<legend><?php echo Text::_('COM_FABRIK_BOOTSTRAP_LIST_OPTIONS')?></legend>
@@ -151,7 +151,7 @@ use Joomla\CMS\Language\Text;
 			<div class="row">
 				<div>
 					<legend></legend>
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<?php foreach ($this->form->getFieldset('links') as $this->field) :
 							echo $this->loadTemplate('control_group');
 						endforeach;
@@ -159,7 +159,7 @@ use Joomla\CMS\Language\Text;
 					</fieldset>
 				</div>
 				<div>
-					<fieldset class="form-horizontal">
+					<fieldset>
 						<?php foreach ($this->form->getFieldset('links2') as $this->field) :
 							echo $this->loadTemplate('control_group');
 						endforeach;
@@ -172,7 +172,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="details-notes">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('notes') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -182,7 +182,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="details-advanced">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('advanced') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_publishing.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_publishing.php
@@ -53,7 +53,7 @@ use Joomla\CMS\Language\Text;
 	<div class="tab-content">
 		<div class="tab-pane active" id="publishing-details">
 			<legend></legend>
-		    <fieldset class="form-horizontal">
+		    <fieldset>
 				<?php foreach ($this->form->getFieldset('publishing-details') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -63,7 +63,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="publishing-rss">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('rss') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;
@@ -73,7 +73,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="publishing-csv">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php
 				foreach ($this->form->getFieldset('csv') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -86,7 +86,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="publishing-oai">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<div class="alert"><?php echo Text::_('COM_FABRIK_OPEN_ARCHIVE_INITIATIVE'); ?></div>
 				<?php foreach ($this->form->getFieldset('open_archive_initiative') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -96,7 +96,7 @@ use Joomla\CMS\Language\Text;
 		</div>
 
 		<div class="tab-pane" id="publishing-search">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<div class="alert"><?php echo Text::_('COM_FABRIK_SPECIFY_ELEMENTS_IN_DETAILS_FILTERS'); ?></div>
 				<?php foreach ($this->form->getFieldset('search') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -107,7 +107,7 @@ use Joomla\CMS\Language\Text;
 
 		<div class="tab-pane" id="publishing-dashboard">
 			<legend></legend>
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<?php foreach ($this->form->getFieldset('dashboard') as $this->field) :
 					echo $this->loadTemplate('control_group');
 				endforeach;

--- a/administrator/components/com_fabrik/views/list/tmpl/default_select_content_type.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/default_select_content_type.php
@@ -24,7 +24,7 @@ $wa->useScript('jquery');
 
 ?>
 <form action="<?php Route::_('index.php?option=com_fabrik'); ?>" method="post" name="adminForm"
-	id="adminForm" class="form-validate form-horizontal">
+	id="adminForm" class="form-validate">
 
 	<div class="alert alert-info">
 		<span class="icon-puzzle"></span> <?php echo Text::_('COM_FABRIK_FIELD_CONTENT_TYPE_INTRO_LABEL'); ?>

--- a/administrator/components/com_fabrik/views/lists/tmpl/confirmdeletebootstrap.php
+++ b/administrator/components/com_fabrik/views/lists/tmpl/confirmdeletebootstrap.php
@@ -47,7 +47,7 @@ Joomla.submitform = function(task, form) {
 		<input type="hidden" name="cid[]" value="<?php echo $id ;?>" />
 	<?php endforeach; ?>
 
-	<fieldset class="form-horizontal">
+	<fieldset>
 		<legend><?php echo Text::_('COM_FABRIK_DELETE_FROM');?></legend>
 		<ul class="adminformlist">
 		<?php for ($i = 0; $i < count($this->items); $i++) :?>

--- a/administrator/components/com_fabrik/views/visualization/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/visualization/tmpl/bootstrap.php
@@ -29,7 +29,7 @@ HTMLHelper::_('behavior.keepalive');
 	<div class="row">
 
 		<div class="col-md-6">
-			<fieldset class="form-horizontal">
+			<fieldset>
 				<legend><?php echo Text::_('COM_FABRIK_DETAILS'); ?></legend>
 				<?php foreach ($this->form->getFieldset('details') as $this->field) :
 					echo $this->loadTemplate('control_group');
@@ -40,7 +40,7 @@ HTMLHelper::_('behavior.keepalive');
 
 		<div class="col-md-5">
 			<div class="offset2">
-				<fieldset class="form-horizontal">
+				<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_GROUP_LABEL_PUBLISHING_DETAILS');?>
 						</legend>
@@ -50,7 +50,7 @@ HTMLHelper::_('behavior.keepalive');
 					?>
 				</fieldset>
 
-				<fieldset class="form-horizontal">
+				<fieldset>
 						<legend>
 							<?php echo Text::_('COM_FABRIK_VISUALIZATION_LABEL_VISUALIZATION_DETAILS');?>
 						</legend>
@@ -65,7 +65,7 @@ HTMLHelper::_('behavior.keepalive');
 	<div class="row">
 
 		<div class="col-md-12">
-		<fieldset class="form-horizontal">
+		<fieldset>
 		    	<legend>
 		    		<?php echo Text::_('COM_FABRIK_OPTIONS');?>
 		    	</legend>

--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -4973,16 +4973,6 @@ class FabrikFEModelForm extends FabModelForm
 			$group->repeatIntro = $groupParams->get('repeat_intro', '');
 
 			$group->classArray[] = 'fabrikGroup';
-
-			if ((int) $groupParams->get('group_columns', 1) == 1)
-			{
-				if (($this->isEditable() && $groupModel->labelPosition('form') !== 1)
-					|| (!$this->isEditable() && $groupModel->labelPosition('details') !== 1))
-				{
-					$group->classArray[] = 'form-horizontal';
-				}
-			}
-
 			$group->class = implode(' ', $group->classArray);
 			$group->newGroup = $newGroup;
 

--- a/components/com_fabrik/models/plugin.php
+++ b/components/com_fabrik/models/plugin.php
@@ -433,9 +433,7 @@ class FabrikPlugin extends CMSPlugin
 				$str[]    = '<div role="tabpanel" class="tab-pane' . $tabClass . '" id="tab-' . $fieldset->name . '-' . $repeatCounter . '">';
 			}
 
-//			$class = $j3 ? 'form-horizontal ' : 'adminform ';
-			$class = 'form-horizontal ';
-			$class .= $type . 'Settings page-' . $this->_name;
+			$class = $type . 'Settings page-' . $this->_name;
 			$repeat = isset($fieldset->repeatcontrols) && $fieldset->repeatcontrols == 1;
 
 			// Bind data for repeat groups

--- a/components/com_fabrik/views/details/tmpl/bootstrap/template_css.php
+++ b/components/com_fabrik/views/details/tmpl/bootstrap/template_css.php
@@ -25,7 +25,7 @@ echo <<<EOT
 }
 
 /* Override BS2 form horizontal labels for details view when fabrik form module */
-.fabrikDetails.fabrikIsMambot .form-horizontal .control-label {
+.fabrikDetails.fabrikIsMambot .control-label {
 	width: auto;
 	text-align: left;
 }

--- a/plugins/fabrik_visualization/fullcalendar/layouts/fabrik-visualization-fullcalendar-viewevent.php
+++ b/plugins/fabrik_visualization/fullcalendar/layouts/fabrik-visualization-fullcalendar-viewevent.php
@@ -3,7 +3,7 @@ defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Language\Text;
 ?>
-<div class="form-horizontal" id="viewDetails">
+<div id="viewDetails">
 	<div class="row">
 		<div class="col-md-12" data-role="fabrik-popup-template">
 


### PR DESCRIPTION
As some templates still have css for this it was messing up some layouts on the front end.