### PR TITLE
Fix databasejoin autocomplete

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -6889,7 +6889,7 @@ class PlgFabrik_Element extends FabrikPlugin
 		}
 		else
 		{
-			echo $cache->get(array(get_class($this), 'cacheAutoCompleteOptions'), $this, $search);
+			echo $cache->get(array(get_class($this), 'cacheAutoCompleteOptions'), [$this, $search]);
 		}
 	}
 


### PR DESCRIPTION
Cache->get needs to pass an array or arguments, not just a list of them.

Don't know how this ever worked.