### PR TITLE
Don't return if there is no slug, the pk becomes the slug

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2832,12 +2832,13 @@ class FabrikFEModelList extends FormModel
 
 		if (in_array($this->outputFormat, array('raw', 'html', 'partial', 'feed', 'pdf', 'phocapdf')))
 		{
+			$slugElement = null;
 			$slug = $params->get('sef-slug');
-			if (empty($slug)) return;
-			$raw = StringHelper::substr($slug, StringHelper::strlen($slug) - 4, 4) == '_raw' ? true : false;
-			$slug = FabrikString::rtrimword($slug, '_raw');
-			$slugElement = $formModel->getElement($slug);
-
+			if (!empty($slug)) {
+				$raw = StringHelper::substr($slug, StringHelper::strlen($slug) - 4, 4) == '_raw' ? true : false;
+				$slug = FabrikString::rtrimword($slug, '_raw');
+				$slugElement = $formModel->getElement($slug);
+			}
 			if ($slugElement)
 			{
 				$slug = $slugElement->getSlugName($raw);


### PR DESCRIPTION
Bad implementation of the null string warning fix. My bad.