### PR TITLE
Fabrik list module

### DIFF
--- a/administrator/modules/mod_fabrik_list/mod_fabrik_list.xml
+++ b/administrator/modules/mod_fabrik_list/mod_fabrik_list.xml
@@ -36,8 +36,7 @@
 
 				<field name="list_id" type="fabriktables" description="MOD_FABRIK_LIST_LIST_DESC" label="MOD_FABRIK_LIST_LIST_LABEL"/>
 
-				<field name="useajax" type="list" default="" description="MOD_FABRIK_LIST_AJAX_DESC" label="MOD_FABRIK_LIST_AJAX_LABEL">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
+				<field name="useajax" type="list" default="1" description="MOD_FABRIK_LIST_AJAX_DESC" label="MOD_FABRIK_LIST_AJAX_LABEL">
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>

--- a/modules/mod_fabrik_list/mod_fabrik_list.php
+++ b/modules/mod_fabrik_list/mod_fabrik_list.php
@@ -15,7 +15,7 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
-use Fabrik\Helpers\ArrayHelper;
+//use Fabrik\Helpers\ArrayHelper;
 
 if (!defined('COM_FABRIK_FRONTEND'))
 {
@@ -29,11 +29,11 @@ BaseDatabaseModel::addIncludePath(COM_FABRIK_FRONTEND . '/models', 'FabrikFEMode
 BaseDatabaseModel::addIncludePath(COM_FABRIK_FRONTEND . '/models');
 BaseDatabaseModel::addIncludePath(COM_FABRIK_BASE . '/administrator/components/com_fabrik/tables');
 
-require_once COM_FABRIK_FRONTEND . '/controller.php';
+//require_once COM_FABRIK_FRONTEND . '/controller.php';
 require_once COM_FABRIK_FRONTEND . '/controllers/list.php';
 require_once COM_FABRIK_FRONTEND . '/views/list/view.html.php';
-require_once COM_FABRIK_FRONTEND . '/views/package/view.html.php';
-require_once COM_FABRIK_FRONTEND . '/controllers/package.php';
+//require_once COM_FABRIK_FRONTEND . '/views/package/view.html.php';
+//require_once COM_FABRIK_FRONTEND . '/controllers/package.php';
 require_once COM_FABRIK_FRONTEND . '/views/form/view.html.php';
 
 // Load front end language file as well
@@ -78,7 +78,7 @@ $listels = json_decode($params->get('list_elements'));
 
 if ($listId === 0)
 {
-	JError::raiseError(500, 'no list specified');
+	throw new Exception('no list specified',500);
 }
 
 if (isset($listels->show_in_list))
@@ -192,7 +192,7 @@ if (!empty($conditions))
 
 $model->randomRecords = $random;
 
-if (!JError::isError($model))
+if (!($model INSTANCEOF Exception))
 {
 	$view->setModel($model, true);
 }
@@ -202,7 +202,7 @@ $view->isMambot = true;
 $input->set('itemId', $params->get('itemId', $origItemId));
 
 // Display the view
-$view->error = $controller->getError();
+//$view->error = $controller->getError();
 echo $view->display();
 
 $input->set('itemId', $origItemId);

--- a/modules/mod_fabrik_list/mod_fabrik_list.php
+++ b/modules/mod_fabrik_list/mod_fabrik_list.php
@@ -14,8 +14,8 @@ defined('_JEXEC') or die('Restricted access');
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Factory;
-use Joomla\Utilities\ArrayHelper;
-//use Fabrik\Helpers\ArrayHelper;
+//use Joomla\Utilities\ArrayHelper;
+use Fabrik\Helpers\ArrayHelper;
 
 if (!defined('COM_FABRIK_FRONTEND'))
 {

--- a/modules/mod_fabrik_list/mod_fabrik_list.xml
+++ b/modules/mod_fabrik_list/mod_fabrik_list.xml
@@ -25,7 +25,7 @@
 
 				<field name="itemId" type="menuitem" description="MOD_FABRIK_LIST_ITEMID_DESC" label="MOD_FABRIK_LIST_ITEMID_LABEL"/>
 
-				<field name="useajax" class="btn-group" type="radio" default="0" layout="joomla.form.field.radio.switcher" description="MOD_FABRIK_LIST_AJAX_DESC" label="MOD_FABRIK_LIST_AJAX_LABEL">
+				<field name="useajax" class="btn-group" type="radio" default="1" layout="joomla.form.field.radio.switcher" description="MOD_FABRIK_LIST_AJAX_DESC" label="MOD_FABRIK_LIST_AJAX_LABEL">
 						<option value="0">JNO</option>
 						<option value="1">JYES</option>
 				</field>


### PR DESCRIPTION
List modules must have list ajaxfied (at least if not readonly), so set default to YES (This is a common issue in F3 forum).
admin xml: There's no global setting

//require_once COM_FABRIK_FRONTEND . '/controller.php'; //is deprecated
//$view->error = $controller->getError(); see https://github.com/joomlahenk/fabrik/issues/136