### PR TITLE
Set mediabox as default

### DIFF
--- a/administrator/components/com_fabrik/config.xml
+++ b/administrator/components/com_fabrik/config.xml
@@ -459,7 +459,7 @@
 
 		<field name="use_mediabox"
 			type="list"
-			default="0" description="COM_FABRIK_MEDIA_BOX_DESC"
+			default="1" description="COM_FABRIK_MEDIA_BOX_DESC"
 			label="COM_FABRIK_MEDIA_BOX_LABEL"
 			class="radio btn-group">
 				<option value="0">COM_FABRIK_LIGHTBOX_SLIMBOX</option>

--- a/libraries/fabrik/fabrik/Helpers/Html.php
+++ b/libraries/fabrik/fabrik/Helpers/Html.php
@@ -1760,7 +1760,7 @@ EOD;
 				return;
 			}
 
-			if ($fbConfig->get('use_mediabox', false))
+			if ($fbConfig->get('use_mediabox', 1))
 			{
 				$folder  = 'components/com_fabrik/libs/mediabox-advanced/';
 				$mbStyle = $fbConfig->get('mediabox_style', 'Dark');


### PR DESCRIPTION
Slimbox is not working. Keep the option for now but set Mediabox as default.
