### PR TITLE
Hack to redisplay the sidebar menu items for list and group displays

### DIFF
--- a/administrator/components/com_fabrik/views/group/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/group/tmpl/bootstrap.php
@@ -30,16 +30,16 @@ HTMLHelper::_('behavior.keepalive');
 	<div class="row main-card-columns">
 		<div class="col-sm-2" id="sidebar">
 			<div class="nav flex-column nav-pills">
-				<button class="nav-link active" id="" data-bs-toggle="pill" data-bs-target="#details-info" type="button" role="tab" aria-controls="" aria-selected="true">
+				<button class="nav-link active" id="btn-details" data-bs-toggle="pill" data-bs-target="#details-info" type="button" role="tab" aria-controls="" aria-selected="true">
 					<?php echo Text::_('COM_FABRIK_DETAILS')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#details-repeat" type="button" role="tab" aria-controls="" aria-selected="true">
+				<button class="nav-link" id="btn-repeat" data-bs-toggle="pill" data-bs-target="#details-repeat" type="button" role="tab" aria-controls="" aria-selected="true">
 					<?php echo Text::_('COM_FABRIK_REPEAT')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#details-layout" type="button" role="tab" aria-controls="" aria-selected="true">
+				<button class="nav-link" id="btn-layout" data-bs-toggle="pill" data-bs-target="#details-layout" type="button" role="tab" aria-controls="" aria-selected="true">
 					<?php echo Text::_('COM_FABRIK_LAYOUT')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#details-multipage" type="button" role="tab" aria-controls="" aria-selected="true">
+				<button class="nav-link" id="btn-multipage" data-bs-toggle="pill" data-bs-target="#details-multipage" type="button" role="tab" aria-controls="" aria-selected="true">
 					<?php echo Text::_('COM_FABRIK_GROUP_MULTIPAGE')?>
 				</button>
 			</div>

--- a/administrator/components/com_fabrik/views/group/view.html.php
+++ b/administrator/components/com_fabrik/views/group/view.html.php
@@ -78,6 +78,31 @@ class FabrikAdminViewGroup extends HtmlView
 		FabrikHelperHTML::script($srcs);
 
 		parent::display($tpl);
+
+		/* The following is a hack to fix an issue with the list and group admin forms losing
+		 * the sidebar menu item above the one the user clicks on before fabrik is fully loaded. 
+		 * This hack forces it to redisplay 
+		*/
+		Factory::getDocument()->addScriptDeclaration('
+			function onReady() {
+			    var details = document.getElementById("btn-details");
+			    if (typeof Fabrik !== "undefined" && details !== null) {
+			    	var buttons = ["btn-details", "btn-repeat", "btn-layout", "btn-multipage"];
+			    	for (var idx = 0; idx < buttons.length; idx++) {
+			    		button = document.getElementById(buttons[idx]);
+			    		if (button.style.display == "none") button.style.display = "block";
+			    	}
+			    } else {
+			    	setTimeout(onReady, 100);
+			    }
+			}
+
+			if (document.readyState !== "loading") {
+			    onReady();
+			} else {
+				document.addEventListener("DOMContentLoaded", onReady());
+			}'
+		);
 	}
 
 	/**

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap.php
@@ -47,19 +47,19 @@ HTMLHelper::_('behavior.keepalive');
 	<div class="row main-card-columns">
 		<div class="col-sm-2" id="sidebar">
 			<div class="nav flex-column nav-pills">
-				<button class="nav-link active" id="" data-bs-toggle="pill" data-bs-target="#detailsX" type="button" role="tab" aria-controls="" aria-selected="true">
+				<button class="nav-link active" id="btn-details" data-bs-toggle="pill" data-bs-target="#detailsX" type="button" role="tab" aria-controls="" aria-selected="true" style="display:block">
 					<?php echo Text::_('COM_FABRIK_DETAILS')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#data" type="button" role="tab" aria-controls="" aria-selected="false">
+				<button class="nav-link" id="btn-data" data-bs-toggle="pill" data-bs-target="#data" type="button" role="tab" aria-controls="" aria-selected="false">
 					<?php echo Text::_('COM_FABRIK_DATA')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#publishing" type="button" role="tab" aria-controls="" aria-selected="false">
+				<button class="nav-link" id="btn-publishing" data-bs-toggle="pill" data-bs-target="#publishing" type="button" role="tab" aria-controls="" aria-selected="false">
 					<?php echo Text::_('COM_FABRIK_GROUP_LABEL_PUBLISHING_DETAILS')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#access" type="button" role="tab" aria-controls="" aria-selected="false">
+				<button class="nav-link" id="btn-access" data-bs-toggle="pill" data-bs-target="#access" type="button" role="tab" aria-controls="" aria-selected="false">
 					<?php echo Text::_('COM_FABRIK_GROUP_LABEL_RULES_DETAILS')?>
 				</button>
-				<button class="nav-link" id="" data-bs-toggle="pill" data-bs-target="#tabplugins" type="button" role="tab" aria-controls="" aria-selected="false">
+				<button class="nav-link" id="btn-plugins" data-bs-toggle="pill" data-bs-target="#tabplugins" type="button" role="tab" aria-controls="" aria-selected="false">
 					<?php echo Text::_('COM_FABRIK_GROUP_LABEL_PLUGINS_DETAILS')?>
 				</button>
 			</div>

--- a/administrator/components/com_fabrik/views/list/view.html.php
+++ b/administrator/components/com_fabrik/views/list/view.html.php
@@ -139,6 +139,31 @@ class FabrikAdminViewList extends HtmlView
 		FabrikHelperHTML::iniRequireJS($shim);
 		FabrikHelperHTML::script($srcs, $this->js);
 		parent::display($tpl);
+
+		/* The following is a hack to fix an issue with the list and group admin forms losing
+		 * the sidebar menu item above the one the user clicks on before fabrik is fully loaded. 
+		 * This hack forces it to redisplay 
+		*/
+		Factory::getDocument()->addScriptDeclaration('
+			function onReady() {
+			    var details = document.getElementById("btn-details");
+			    if (typeof Fabrik !== "undefined" && details !== null) {
+			    	var buttons = ["btn-details", "btn-data", "btn-publishing", "btn-access", "btn-plugins"];
+			    	for (var idx = 0; idx < buttons.length; idx++) {
+			    		button = document.getElementById(buttons[idx]);
+			    		if (button.style.display == "none") button.style.display = "block";
+			    	}
+			    } else {
+			    	setTimeout(onReady, 100);
+			    }
+			}
+
+			if (document.readyState !== "loading") {
+			    onReady();
+			} else {
+				document.addEventListener("DOMContentLoaded", onReady());
+			}'
+		);
 	}
 
 	/**


### PR DESCRIPTION
For some reason if you click on one of these before Fabrik has fully initialized, the menu item immediately above gets set to display:none. This hack waits for Fabrik to initialize and once it does checks if any item was hidden and if so displays it again.

User will see a momentary (less than a second) loss of a menu item and then it will come back.