### PR TITLE
yesno with switcher, detailsview, modal front/backend

### DIFF
--- a/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
+++ b/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
@@ -34,7 +34,7 @@ if ($data == '1') :
     }
     else
     {
-        $icon = $j3 && $format != 'pdf' ? 'checkmark' : '1.png';
+        $icon = $format != 'pdf' ? 'checkmark' : '1.png';
     }
 
 	$properties['alt'] = Text::_('JYES');
@@ -47,7 +47,7 @@ else :
     }
     else
     {
-        $icon = $j3 && $format != 'pdf' ? 'remove' : '0.png';
+        $icon = $format != 'pdf' ? 'remove' : '0.png';
     }
 
 	$properties['alt'] = Text::_('JNO');


### PR DESCRIPTION
This is working in my front- and backend in modal forms.

The only difference to @skurvish PR: use full path with Juri::root() 
because "media/..." will look in administrator/media/... and "/media/..." will skip any subdirectory (so trying to load non-existing files http://localhost/media... instead of http://localhost/my-joomla-dir/media...)