### PR TITLE
One more id string/int comparison

### DIFF
--- a/media/com_fabrik/js/list.js
+++ b/media/com_fabrik/js/list.js
@@ -1112,7 +1112,7 @@ define(['jquery', 'fab/fabrik', 'fab/list-toggle', 'fab/list-grouped-toggler', '
                 Object.each(this.options.data, function (group) {
                     for (var i = 0; i < group.length; i++) {
                         var row = group[i];
-                        if (row && row.data.__pk_val === id) {
+                        if (row && row.data.__pk_val == id) {
                             found = row.data;
                         }
                     }


### PR DESCRIPTION
Again here id is string, row.data._pk_val is int.

list.js needs minifying (to /dist/)

Solves https://github.com/joomlahenk/fabrik/issues/437