### PR TITLE
Add a width as temp. fix to admin bootstrap_control_group

### DIFF
--- a/administrator/components/com_fabrik/views/form/tmpl/bootstrap_control_group.php
+++ b/administrator/components/com_fabrik/views/form/tmpl/bootstrap_control_group.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die('Restricted access');
 		<?php echo $this->field->label; ?>
 	</div>
 <?php endif; ?>
-	<div>
+	<div style="width:75%">
 		<?php echo $this->field->input; ?>
 	</div>
 </div>

--- a/administrator/components/com_fabrik/views/group/tmpl/bootstrap_control_group.php
+++ b/administrator/components/com_fabrik/views/group/tmpl/bootstrap_control_group.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die('Restricted access');
 		<?php echo $this->field->label; ?>
 	</div>
 <?php endif; ?>
-	<div>
+	<div style="width:75%">
 		<?php echo $this->field->input; ?>
 	</div>
 </div>

--- a/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_control_group.php
+++ b/administrator/components/com_fabrik/views/list/tmpl/admin_bootstrap_control_group.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die('Restricted access');
 		<?php echo $this->field->label; ?>
 	</div>
 <?php endif; ?>
-	<div>
+	<div style="width:75%">
 		<?php echo $this->field->input; ?>
 	</div>
 </div>


### PR DESCRIPTION
.control-group div without any class doesn't have a width which will break editors and also input field widths (not showing the complete text etc)
So add one (until Atum and our bootstrap_control_group templates are really BS5)