### PR TITLE
Fix ajax validation icons in dropdowns +error group indication in bootstrap_tabs template.

### DIFF
--- a/components/com_fabrik/layouts/fabrik-tabs.php
+++ b/components/com_fabrik/layouts/fabrik-tabs.php
@@ -14,14 +14,14 @@ $i = 0;
 <ul class="nav nav-tabs" role="tablist">
 	<?php foreach ($d->tabs as $tab) :
 		$style = array();
-		$style[] = isset($tab->class) && $tab->class !== '' ? 'class="' . $tab->class . '"' : '';
 		$style[] = isset($tab->css) && $tab->css !== '' ? 'style="' . $tab->css . '"': '';
+		$tab_class = isset($tab->class) && $tab->class !== '' ? $tab->class : '';
 		$href = isset($tab->href) ? $tab->href : $tab->id;
-		$i==0 ? $active = 'active' : $active = '';
+		$i==0 ? $active = ' active ' : $active = '';
 		$i==0 ? $selected = 'true' : $selected = 'false';
 		?>
 		<li role="presentation" class="nav-item" <?php echo implode(' ', $style); ?>>
-			<button class="nav-link <?php echo $active; ?>" id="<?php echo $tab->id; ?>" data-bs-toggle="tab" data-bs-target="#<?php echo $href; ?>" type="button" role="tab" aria-controls="<?php echo $tab->href; ?>" aria-selected="<?php echo $selected;?>">
+			<button class="nav-link <?php echo $active . $tab_class; ?>" id="<?php echo $tab->id; ?>" data-bs-toggle="tab" data-bs-target="#<?php echo $href; ?>" type="button" role="tab" aria-controls="<?php echo $tab->href; ?>" aria-selected="<?php echo $selected;?>">
 				<?php echo Text::_($tab->label); ?>
 			</button>
 		</li>

--- a/components/com_fabrik/views/form/tmpl/bootstrap/template_css.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap/template_css.php
@@ -20,6 +20,10 @@ clear: left;
     color: var(--body-color);
     font-size: 1rem;
 }
-
+/*BS5 ajax validation: icons overriding dropdown caret*/
+.fabrikinput.form-select {
+    background-position: right 1rem center, center right 0.1rem !important;
+	 padding-right:0 !important;
+}
 ";
 ?>

--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
@@ -78,7 +78,7 @@ foreach ($this->groups as $group) :
 			break;
 		}
 	}
-	$err_class = $is_err ? 'fabrikErrorGroup' : '';
+	$err_class = $is_err ? ' fabrikErrorGroup' : '';
 	$tabId = $this->form->id . '_' . (int)$this->rowid . '_' . $i;
 	// If this is multi-page then groups are consolidated until a group with a page break
 	// So we should only show a tab if: it is first tab, or if it is a page break
@@ -86,8 +86,7 @@ foreach ($this->groups as $group) :
 		$is_err = false;
 		$tab = new stdClass;
 		$tab->id = 'group' . $group->id . '_tab';
-		$tab->class = $i === 0 ? 'active ' . $err_class : $err_class;
-		$tab->class .= ' ' . $tab->id . '_tab';
+		$tab->class = $err_class;
 		$tab->css = $group->css;
 		$tab->href = 'group-tab' . $tabId;
 		$tab->label = !empty($group->title) ? $group->title : $group->name;;

--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/template_css.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/template_css.php
@@ -18,25 +18,15 @@ clear: left;
 }
 
 /* color & highlight group with validation errors */
-.fabrikErrorGroup a {
+.fabrikErrorGroup {
     background-color: rgb(242, 222, 222) !important;
   color: #b94a48;
 }
  
-.active.fabrikErrorGroup a,
-.active.fabrikErrorGroup a:hover,
-.active.fabrikErrorGroup a:focus {
-    border: 1px solid #b94a48 !important;
-    border-bottom-color: transparent !important;
-  color: #b94a48 !important;
-  background-color: rgb(255, 255, 255) !important;
+/*BS5 ajax validation: icons overriding dropdown caret*/
+.fabrikinput.form-select {
+    background-position: right 1rem center, center right 0.1rem !important;
+	 padding-right:0 !important;
 }
- 
-.fabrikErrorGroup a:hover,
-.fabrikErrorGroup a:focus {
-    background-color: rgb(222, 173, 173) !important;
-  color: #b94a48;
-}
-
 ";
 ?>


### PR DESCRIPTION
Ajax validation: It's only CSS, the same in Atum and Cassiopeia
I don't know if it's a general BS5 issue, but anyway - overridden in template_php.css