### PR TITLE
Typo in Googlemap viz, deprecated warning in Googlemaps element

### DIFF
--- a/plugins/fabrik_element/googlemap/googlemap.php
+++ b/plugins/fabrik_element/googlemap/googlemap.php
@@ -716,7 +716,7 @@ class PlgFabrik_ElementGooglemap extends PlgFabrik_Element
 			$z = $params->get('fb_gm_zoomlevel');
 		}
 
-		$icon = urlencode($params->get('fb_gm_staticmap_icon'));
+		$icon = urlencode($params->get('fb_gm_staticmap_icon',''));
 		$o = $this->_strToCoords($v, $z);
 		$lat = trim($o->coords[0]);
 		$lon = trim($o->coords[1]);

--- a/plugins/fabrik_visualization/googlemap/models/googlemap.php
+++ b/plugins/fabrik_visualization/googlemap/models/googlemap.php
@@ -309,7 +309,7 @@ class FabrikModelGooglemap extends FabrikFEModelVisualization
 	 */
 	private function getCordsFromData($d)
 	{
-		if (empty($v)) return [0,0];
+		if (empty($d)) return [0,0];
 		
 		$v = str_replace(' ', '', $d);
 		$v = trim($v);


### PR DESCRIPTION
Typo in Googlemap viz, deprecated warning in Googlemaps element